### PR TITLE
Avoid files other than png to be readable

### DIFF
--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -176,7 +176,7 @@ const integrationsStatic = express.static(
   { maxAge: dayMs, fallthrough: false }
 );
 app.use('/integrations', (req, res, next) => {
-  if (req.url.endsWith('png')) {
+  if (req.path.endsWith('.png')) {
     return integrationsStatic(req, res, (err) => {
       ArkimeUtil.missingResource(err, req, res);
     });


### PR DESCRIPTION
The check incorrectly checked that the URL finished by 'png' - that includes the query string. Fixing the condition to only check the path, and check for `.png` instead of just `png`

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
